### PR TITLE
fix: network tags property and cleanup script

### DIFF
--- a/pkg/resources/network/network.go
+++ b/pkg/resources/network/network.go
@@ -91,9 +91,11 @@ func networkToProperties(net *networkWithMTU) map[string]interface{} {
 		props["mtu"] = net.MTU
 	}
 
-	// Add tags if present
+	// Always include tags - use empty list if none (matches schema default)
 	if len(net.Tags) > 0 {
 		props["tags"] = net.Tags
+	} else {
+		props["tags"] = []string{}
 	}
 
 	return props


### PR DESCRIPTION
## Summary
- Fix conformance test failure for network replace test
- Fix cleanup script warnings for Ext-Net subnets

## Changes

### 1. Network plugin now always returns tags property
The network plugin was conditionally returning tags only when non-empty. However, the Pkl schema has a default of `tags: Listing<String>? = new Listing {}` (empty list). This caused the conformance test to fail after replace operation:
```
runner.go:164: Property tags should exist in actual resource (after replace)
```

Now the plugin always returns `tags` (empty list when none), matching the schema default.

### 2. Cleanup script no longer tries to delete provider-managed subnets
The script was listing ALL subnets and trying to delete them, including Ext-Net subnets which are provider-managed and cannot be deleted. Now it only deletes subnets from internal/private networks.

This eliminates the many "Warning: Failed to delete" messages for external subnets.

## Test plan
- [ ] Conformance tests should pass (network test specifically)
- [ ] Cleanup script should no longer show warnings for Ext-Net subnets