### PR TITLE
feat: add TIMEOUT parameter for conformance tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,23 +90,24 @@ clean-environment:
 	@./scripts/ci/clean-environment.sh
 
 ## conformance-test: Run all conformance tests (CRUD + discovery)
-## Usage: make conformance-test [VERSION=0.80.0] [TEST=s3-bucket]
+## Usage: make conformance-test [VERSION=0.80.0] [TEST=s3-bucket] [TIMEOUT=15]
 ## Downloads the specified formae version (or latest) and runs conformance tests.
 ## Calls setup-credentials and clean-environment automatically.
 ##
 ## Parameters:
 ##   VERSION - Formae version to test against (default: latest)
 ##   TEST    - Filter tests by name pattern (e.g., TEST=s3-bucket)
+##   TIMEOUT - Timeout in minutes for long-running operations (default: 5)
 conformance-test: conformance-test-crud conformance-test-discovery
 
 ## conformance-test-crud: Run only CRUD lifecycle tests
-## Usage: make conformance-test-crud [VERSION=0.80.0] [TEST=s3-bucket]
+## Usage: make conformance-test-crud [VERSION=0.80.0] [TEST=s3-bucket] [TIMEOUT=15]
 conformance-test-crud: install setup-credentials
 	@echo "Pre-test cleanup..."
 	@./scripts/ci/clean-environment.sh || true
 	@echo ""
 	@echo "Running CRUD conformance tests..."
-	@FORMAE_TEST_FILTER="$(TEST)" FORMAE_TEST_TYPE=crud ./scripts/run-conformance-tests.sh $(VERSION); \
+	@FORMAE_TEST_FILTER="$(TEST)" FORMAE_TEST_TYPE=crud FORMAE_TEST_TIMEOUT="$(TIMEOUT)" ./scripts/run-conformance-tests.sh $(VERSION); \
 	TEST_EXIT=$$?; \
 	echo ""; \
 	echo "Post-test cleanup..."; \
@@ -114,13 +115,13 @@ conformance-test-crud: install setup-credentials
 	exit $$TEST_EXIT
 
 ## conformance-test-discovery: Run only discovery tests
-## Usage: make conformance-test-discovery [VERSION=0.80.0] [TEST=s3-bucket]
+## Usage: make conformance-test-discovery [VERSION=0.80.0] [TEST=s3-bucket] [TIMEOUT=15]
 conformance-test-discovery: install setup-credentials
 	@echo "Pre-test cleanup..."
 	@./scripts/ci/clean-environment.sh || true
 	@echo ""
 	@echo "Running discovery conformance tests..."
-	@FORMAE_TEST_FILTER="$(TEST)" FORMAE_TEST_TYPE=discovery ./scripts/run-conformance-tests.sh $(VERSION); \
+	@FORMAE_TEST_FILTER="$(TEST)" FORMAE_TEST_TYPE=discovery FORMAE_TEST_TIMEOUT="$(TIMEOUT)" ./scripts/run-conformance-tests.sh $(VERSION); \
 	TEST_EXIT=$$?; \
 	echo ""; \
 	echo "Post-test cleanup..."; \

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ovh/go-ovh v1.9.0
 	github.com/platform-engineering-labs/formae/pkg/model v0.1.2
 	github.com/platform-engineering-labs/formae/pkg/plugin v0.1.8
-	github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests v0.1.12
+	github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests v0.1.14
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,8 @@ github.com/platform-engineering-labs/formae/pkg/model v0.1.2 h1:FgjN2mS/9bLAlRIb
 github.com/platform-engineering-labs/formae/pkg/model v0.1.2/go.mod h1:XmGJA7jNPX9cEGc8TxTiEDitBuEVJOddNakdTZ/bH4U=
 github.com/platform-engineering-labs/formae/pkg/plugin v0.1.8 h1:bECZEPHo6I6P8Qmpes5kDW/RFco3P7Z5xB3vvEuDGTo=
 github.com/platform-engineering-labs/formae/pkg/plugin v0.1.8/go.mod h1:KzNzkc67phbeqs61ji+r8Y1WCD5QnDEpU7rfUHkmmuQ=
-github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests v0.1.12 h1:vhaOH86UkiYcCHiRtY636d6F7vMbMqGPrQUdMO6S63E=
-github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests v0.1.12/go.mod h1:NuoGHFF4WCI73scZ4odspPzZiKCWRvrKWTvy0rgoNec=
+github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests v0.1.14 h1:DBNLBhpyQHwmO+On6lo2RBrfNM6uked7acDvn/Rvpnc=
+github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests v0.1.14/go.mod h1:NuoGHFF4WCI73scZ4odspPzZiKCWRvrKWTvy0rgoNec=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=


### PR DESCRIPTION
## Summary

- Bump `plugin-conformance-tests` to v0.1.13
- Add `TIMEOUT` parameter to Makefile conformance test targets
- Passes `FORMAE_TEST_TIMEOUT` environment variable for slow resources

## Usage

```bash
# Default 5-minute timeout
make conformance-test

# 15-minute timeout for slow resources
make conformance-test TIMEOUT=15
```

## Related

- platform-engineering-labs/formae#213