### PR TITLE
feat(kube): add conformance tests and fix cluster CRUD plumbing

### DIFF
--- a/pkg/resources/cloud/kube/cluster.go
+++ b/pkg/resources/cloud/kube/cluster.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/platform-engineering-labs/formae/pkg/plugin"
 	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
 	"github.com/platform-engineering-labs/formae-plugin-ovh/pkg/resources/prov"
 	"github.com/platform-engineering-labs/formae-plugin-ovh/pkg/resources/registry"
@@ -27,6 +28,8 @@ type clusterProvisioner struct {
 var _ prov.Provisioner = &clusterProvisioner{}
 
 func (p *clusterProvisioner) Create(ctx context.Context, request *resource.CreateRequest) (*resource.CreateResult, error) {
+	log := plugin.LoggerFromContext(ctx)
+
 	var props map[string]interface{}
 	if err := json.Unmarshal(request.Properties, &props); err != nil {
 		return createFailure(resource.OperationErrorCodeInvalidRequest,
@@ -42,8 +45,12 @@ func (p *clusterProvisioner) Create(ctx context.Context, request *resource.Creat
 	// Build URL: POST /cloud/project/{project}/kube
 	url := fmt.Sprintf("/cloud/project/%s/kube", project)
 
-	// Strip serviceName from body (it's in the URL)
-	body := filterProps(props, "serviceName")
+	// Strip serviceName (URL-only) and output-only fields that OVH rejects on POST.
+	body := filterProps(props, "serviceName",
+		"id", "status", "url", "nodesUrl", "isUpToDate",
+		"controlPlaneIsUpToDate", "nextUpgradeVersions", "kubeconfig")
+
+	log.Debug("kube cluster create request", "url", url, "body", body)
 
 	response, err := p.client.Do(ctx, ovhtransport.RequestOptions{
 		Method: "POST",
@@ -51,6 +58,7 @@ func (p *clusterProvisioner) Create(ctx context.Context, request *resource.Creat
 		Body:   body,
 	})
 	if err != nil {
+		log.Debug("kube cluster create failed", "error", err.Error())
 		return handleTransportError(err), nil
 	}
 
@@ -116,9 +124,16 @@ func (p *clusterProvisioner) Update(ctx context.Context, request *resource.Updat
 
 	url := fmt.Sprintf("/cloud/project/%s/kube/%s", project, kubeID)
 
-	// Strip immutable fields
-	body := filterProps(props, "serviceName", "region", "plan", "kubeProxyMode",
-		"privateNetworkId", "privateNetworkConfiguration", "loadBalancersSubnetId", "nodesSubnetId")
+	// Strip immutable + output-only fields. OVH's PUT /kube/{id} accepts name
+	// and updatePolicy; everything else gets rejected as "Unknown parameter".
+	body := filterProps(props, "serviceName", "region", "version", "plan", "kubeProxyMode",
+		"privateNetworkId", "privateNetworkConfiguration", "loadBalancersSubnetId", "nodesSubnetId",
+		"id", "status", "url", "nodesUrl", "isUpToDate",
+		"controlPlaneIsUpToDate", "nextUpgradeVersions", "kubeconfig",
+		"customizationApiserver", "customizationKubeProxy")
+
+	log := plugin.LoggerFromContext(ctx)
+	log.Debug("kube cluster update request", "url", url, "body", body)
 
 	response, err := p.client.Do(ctx, ovhtransport.RequestOptions{
 		Method: "PUT",
@@ -126,6 +141,7 @@ func (p *clusterProvisioner) Update(ctx context.Context, request *resource.Updat
 		Body:   body,
 	})
 	if err != nil {
+		log.Debug("kube cluster update failed", "error", err.Error())
 		if transportErr, ok := err.(*ovhtransport.Error); ok {
 			return updateFailure(request.NativeID, ovhtransport.ToResourceErrorCode(transportErr.Code),
 				transportErr.Message), nil

--- a/pkg/resources/cloud/kube/helpers.go
+++ b/pkg/resources/cloud/kube/helpers.go
@@ -53,10 +53,20 @@ func extractProjectFromAdditional(targetConfig json.RawMessage, additionalProps 
 	return ""
 }
 
-// filterProps returns a copy of props without the specified keys
+// formaeMetadataFields are the fields that Formae attaches to every Resource
+// and are not valid properties on OVH API request bodies. OVH rejects unknown
+// parameters with 400 `Unknown parameter`, so these must be stripped from any
+// POST/PUT body.
+var formaeMetadataFields = []string{"label", "group", "target", "stack", "managed"}
+
+// filterProps returns a copy of props with Formae metadata fields and the
+// caller-specified keys removed. Nil values are also dropped.
 func filterProps(props map[string]interface{}, keys ...string) map[string]interface{} {
 	result := make(map[string]interface{})
 	keySet := make(map[string]bool)
+	for _, k := range formaeMetadataFields {
+		keySet[k] = true
+	}
 	for _, k := range keys {
 		keySet[k] = true
 	}

--- a/schema/pkl/kube/cluster.pkl
+++ b/schema/pkl/kube/cluster.pkl
@@ -117,40 +117,48 @@ open class Cluster extends formae.Resource {
   serviceName: String
 
   /// Cluster name
+  @ovh.FieldHint { required = true }
   name: String?
 
   /// Region where the cluster is deployed
   @ovh.FieldHint { required = true; createOnly = true }
   region: String
 
-  /// Kubernetes version (e.g., "1.28")
-  version: String?
+  /// Kubernetes version (e.g., "1.33").
+  ///
+  /// Accepts a bare String or a `formae.Value` so callers can use
+  /// `new formae.Value { value = "1.33"; strategy = "SetOnce" }` when targeting
+  /// a minor version — OVH picks the current patch (e.g. returns "1.33.10-1")
+  /// and SetOnce tells the renderer not to re-compare the value on read.
+  @ovh.FieldHint { required = true }
+  version: (String|formae.Value)?
 
   /// Cluster plan (empty for default)
-  @ovh.FieldHint { createOnly = true }
+  @ovh.FieldHint { createOnly = true; hasProviderDefault = true }
   plan: String?
 
   /// Update policy for the cluster
+  @ovh.FieldHint
   updatePolicy: UpdatePolicy?
 
   /// Kube-proxy mode
-  @ovh.FieldHint { createOnly = true }
+  @ovh.FieldHint { createOnly = true; hasProviderDefault = true }
   kubeProxyMode: KubeProxyMode?
 
   /// Private network ID (OpenStack network UUID)
-  @ovh.FieldHint { createOnly = true }
+  @ovh.FieldHint { createOnly = true; hasProviderDefault = true }
   privateNetworkId: (String|formae.Resolvable)?
 
   /// Private network configuration
-  @ovh.FieldHint { createOnly = true }
+  @ovh.FieldHint { createOnly = true; hasProviderDefault = true }
   privateNetworkConfiguration: PrivateNetworkConfiguration?
 
   /// Subnet ID for load balancers
-  @ovh.FieldHint { createOnly = true }
+  @ovh.FieldHint { createOnly = true; hasProviderDefault = true }
   loadBalancersSubnetId: (String|formae.Resolvable)?
 
   /// Subnet ID for nodes
-  @ovh.FieldHint { createOnly = true }
+  @ovh.FieldHint { createOnly = true; hasProviderDefault = true }
   nodesSubnetId: (String|formae.Resolvable)?
 
   /// API server customization
@@ -160,37 +168,39 @@ open class Cluster extends formae.Resource {
   customizationKubeProxy: KubeProxyCustomization?
 
   // === Computed/Output fields ===
+  // All have hasProviderDefault = true so conformance Verify doesn't require
+  // them in testdata — they're populated by OVH and returned via Read.
 
   /// Cluster ID
-  @ovh.FieldHint 
+  @ovh.FieldHint { hasProviderDefault = true }
   id: String?
 
   /// Cluster status
-  @ovh.FieldHint 
+  @ovh.FieldHint { hasProviderDefault = true }
   status: ClusterStatus?
 
   /// Kubernetes API URL
-  @ovh.FieldHint 
+  @ovh.FieldHint { hasProviderDefault = true }
   url: String?
 
   /// Nodes URL
-  @ovh.FieldHint 
+  @ovh.FieldHint { hasProviderDefault = true }
   nodesUrl: String?
 
   /// Whether the cluster is up to date
-  @ovh.FieldHint 
+  @ovh.FieldHint { hasProviderDefault = true }
   isUpToDate: Boolean?
 
   /// Whether the control plane is up to date
-  @ovh.FieldHint 
+  @ovh.FieldHint { hasProviderDefault = true }
   controlPlaneIsUpToDate: Boolean?
 
   /// Available upgrade versions
-  @ovh.FieldHint 
+  @ovh.FieldHint { hasProviderDefault = true }
   nextUpgradeVersions: Listing<String>?
 
   /// Kubeconfig for cluster access (base64 encoded)
-  @ovh.FieldHint 
+  @ovh.FieldHint { hasProviderDefault = true }
   kubeconfig: String?
 
   hidden res: ClusterResolvable = new {

--- a/testdata/kube-cluster-update.pkl
+++ b/testdata/kube-cluster-update.pkl
@@ -1,0 +1,27 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+
+import "@formae/formae.pkl"
+
+import "@ovh/kube/cluster.pkl"
+
+import "./config/vars.pkl" as v
+
+forma {
+  v.stack
+  v.target
+
+  new cluster.Cluster {
+    label = "plugin-sdk-test-kubecluster"
+    serviceName = v.serviceName
+    name = "formae-test-\(v.testRunID)-updated" // name is mutable
+    region = v.region
+    version = new formae.Value { value = "1.33"; strategy = "SetOnce" }
+    updatePolicy = "NEVER_UPDATE"
+  }
+}

--- a/testdata/kube-cluster.pkl
+++ b/testdata/kube-cluster.pkl
@@ -1,0 +1,28 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+
+import "@formae/formae.pkl"
+import "@ovh/kube/cluster.pkl"
+
+import "./config/vars.pkl" as v
+
+forma {
+  v.stack
+  v.target
+
+  new cluster.Cluster {
+    label = "plugin-sdk-test-kubecluster"
+    serviceName = v.serviceName
+    name = "formae-test-\(v.testRunID)"
+    region = v.region
+    // OVH echoes back a full patch version (e.g. "1.33.10-1") on Read; wrap in
+    // formae.Value with SetOnce so Verify doesn't strict-compare it.
+    version = new formae.Value { value = "1.33"; strategy = "SetOnce" }
+    updatePolicy = "NEVER_UPDATE"
+  }
+}

--- a/testdata/kube-ip-restriction-update.pkl
+++ b/testdata/kube-ip-restriction-update.pkl
@@ -1,0 +1,37 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+
+import "@formae/formae.pkl"
+
+import "@ovh/kube/cluster.pkl"
+import "@ovh/kube/ip_restriction_kube.pkl"
+
+import "./config/vars.pkl" as v
+
+forma {
+  v.stack
+  v.target
+
+  local testCluster = new cluster.Cluster {
+    label = "plugin-sdk-test-kubeiprestriction-cluster"
+    serviceName = v.serviceName
+    name = "formae-ipr-\(v.testRunID)"
+    region = v.region
+    version = new formae.Value { value = "1.33"; strategy = "SetOnce" }
+    updatePolicy = "NEVER_UPDATE"
+  }
+  testCluster
+
+  new ip_restriction_kube.IpRestriction {
+    label = "plugin-sdk-test-kubeiprestriction"
+    serviceName = v.serviceName
+    kubeId = testCluster.res.id
+    ip = "192.0.2.0/24"
+    description = "Formae conformance test kube IP restriction - updated" // description is mutable
+  }
+}

--- a/testdata/kube-ip-restriction.pkl
+++ b/testdata/kube-ip-restriction.pkl
@@ -1,0 +1,38 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+
+import "@formae/formae.pkl"
+
+import "@ovh/kube/cluster.pkl"
+import "@ovh/kube/ip_restriction_kube.pkl"
+
+import "./config/vars.pkl" as v
+
+forma {
+  v.stack
+  v.target
+
+  // Kubernetes cluster for the IP restriction
+  local testCluster = new cluster.Cluster {
+    label = "plugin-sdk-test-kubeiprestriction-cluster"
+    serviceName = v.serviceName
+    name = "formae-ipr-\(v.testRunID)"
+    region = v.region
+    version = new formae.Value { value = "1.33"; strategy = "SetOnce" }
+    updatePolicy = "NEVER_UPDATE"
+  }
+  testCluster
+
+  new ip_restriction_kube.IpRestriction {
+    label = "plugin-sdk-test-kubeiprestriction"
+    serviceName = v.serviceName
+    kubeId = testCluster.res.id
+    ip = "192.0.2.0/24"
+    description = "Formae conformance test kube IP restriction"
+  }
+}

--- a/testdata/kube-nodepool-update.pkl
+++ b/testdata/kube-nodepool-update.pkl
@@ -1,0 +1,41 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+
+import "@formae/formae.pkl"
+
+import "@ovh/kube/cluster.pkl"
+import "@ovh/kube/nodepool.pkl"
+
+import "./config/vars.pkl" as v
+
+forma {
+  v.stack
+  v.target
+
+  local testCluster = new cluster.Cluster {
+    label = "plugin-sdk-test-nodepool-cluster"
+    serviceName = v.serviceName
+    name = "formae-np-\(v.testRunID)"
+    region = v.region
+    version = new formae.Value { value = "1.33"; strategy = "SetOnce" }
+    updatePolicy = "NEVER_UPDATE"
+  }
+  testCluster
+
+  new nodepool.NodePool {
+    label = "plugin-sdk-test-kubenodepool"
+    serviceName = v.serviceName
+    kubeId = testCluster.res.id
+    name = "formae-pool-\(v.testRunID)"
+    flavorName = "b2-7"
+    desiredNodes = 2 // desiredNodes is mutable
+    minNodes = 1
+    maxNodes = 5 // maxNodes is mutable
+    autoscale = false
+  }
+}

--- a/testdata/kube-nodepool.pkl
+++ b/testdata/kube-nodepool.pkl
@@ -1,0 +1,42 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+
+import "@formae/formae.pkl"
+
+import "@ovh/kube/cluster.pkl"
+import "@ovh/kube/nodepool.pkl"
+
+import "./config/vars.pkl" as v
+
+forma {
+  v.stack
+  v.target
+
+  // Kubernetes cluster for the node pool
+  local testCluster = new cluster.Cluster {
+    label = "plugin-sdk-test-nodepool-cluster"
+    serviceName = v.serviceName
+    name = "formae-np-\(v.testRunID)"
+    region = v.region
+    version = new formae.Value { value = "1.33"; strategy = "SetOnce" }
+    updatePolicy = "NEVER_UPDATE"
+  }
+  testCluster
+
+  new nodepool.NodePool {
+    label = "plugin-sdk-test-kubenodepool"
+    serviceName = v.serviceName
+    kubeId = testCluster.res.id
+    name = "formae-pool-\(v.testRunID)"
+    flavorName = "b2-7"
+    desiredNodes = 1
+    minNodes = 1
+    maxNodes = 3
+    autoscale = false
+  }
+}

--- a/testdata/kube-oidc-update.pkl
+++ b/testdata/kube-oidc-update.pkl
@@ -1,0 +1,37 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+
+import "@formae/formae.pkl"
+
+import "@ovh/kube/cluster.pkl"
+import "@ovh/kube/oidc.pkl"
+
+import "./config/vars.pkl" as v
+
+forma {
+  v.stack
+  v.target
+
+  local testCluster = new cluster.Cluster {
+    label = "plugin-sdk-test-kubeoidc-cluster"
+    serviceName = v.serviceName
+    name = "formae-oidc-\(v.testRunID)"
+    region = v.region
+    version = new formae.Value { value = "1.33"; strategy = "SetOnce" }
+    updatePolicy = "NEVER_UPDATE"
+  }
+  testCluster
+
+  new oidc.Oidc {
+    label = "plugin-sdk-test-kubeoidc"
+    serviceName = v.serviceName
+    kubeId = testCluster.res.id
+    clientId = "formae-test-client"
+    issuerUrl = "https://auth.example.com/realms/formae-test-updated" // issuerUrl is mutable
+  }
+}

--- a/testdata/kube-oidc.pkl
+++ b/testdata/kube-oidc.pkl
@@ -1,0 +1,38 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+
+import "@formae/formae.pkl"
+
+import "@ovh/kube/cluster.pkl"
+import "@ovh/kube/oidc.pkl"
+
+import "./config/vars.pkl" as v
+
+forma {
+  v.stack
+  v.target
+
+  // Kubernetes cluster for OIDC configuration
+  local testCluster = new cluster.Cluster {
+    label = "plugin-sdk-test-kubeoidc-cluster"
+    serviceName = v.serviceName
+    name = "formae-oidc-\(v.testRunID)"
+    region = v.region
+    version = new formae.Value { value = "1.33"; strategy = "SetOnce" }
+    updatePolicy = "NEVER_UPDATE"
+  }
+  testCluster
+
+  new oidc.Oidc {
+    label = "plugin-sdk-test-kubeoidc"
+    serviceName = v.serviceName
+    kubeId = testCluster.res.id
+    clientId = "formae-test-client"
+    issuerUrl = "https://auth.example.com/realms/formae-test"
+  }
+}


### PR DESCRIPTION
## Summary
- Adds 8 kube testdata files (cluster, cluster-update, nodepool(+update), oidc(+update), ip-restriction(+update)).
- Fixes the schema/plugin bugs those tests exposed: missing FieldHints on required input fields, missing provider-default flags on computed fields, too-permissive POST/PUT bodies that OVH rejected, and outdated kube version in testdata.
- `OVH::Kube::Cluster` conformance result: Create ✅ Verify ✅ Extract ✅ Sync ✅ Update ✅ Replace ~ (skipped) Destroy ✅. OOB Del still hits the framework's 2-min timeout (consistent with other slow-teardown OVH resources like volume, s3bucket, private-network — same framework-level limitation, not plugin-level).

## What changed

### Schema (`schema/pkl/kube/cluster.pkl`)
- Added `@ovh.FieldHint` to `name`, `version`, `updatePolicy` — previously dropped from serialization, so OVH's Create received a body with only `region`.
- Added `hasProviderDefault = true` to all computed / server-defaulted fields (`id`, `status`, `url`, `nodesUrl`, `isUpToDate`, `controlPlaneIsUpToDate`, `nextUpgradeVersions`, `kubeconfig`, `plan`, `kubeProxyMode`, `privateNetworkId`, `privateNetworkConfiguration`, `loadBalancersSubnetId`, `nodesSubnetId`).
- Relaxed `version: String?` → `version: (String|formae.Value)?` so callers can use `SetOnce`.

### Plugin (`pkg/resources/cloud/kube/`)
- `helpers.go`: `filterProps` now always strips Formae metadata fields (`label`, `group`, `target`, `stack`, `managed`) in addition to the caller-specified keys. OVH rejected all Create bodies with `[group] Unknown parameter` before this.
- `cluster.go` Create: also filters output-only fields (`id`, `status`, `url`, `nodesUrl`, `isUpToDate`, `controlPlaneIsUpToDate`, `nextUpgradeVersions`, `kubeconfig`). `nextUpgradeVersions` defaulted to `[]` and was echoed back into POST.
- `cluster.go` Update: additionally strips `version`, `customization*` blocks, and the same output-only fields. `PUT /cloud/project/{id}/kube/{cid}` only accepts `name` + `updatePolicy`.
- Added `plugin.LoggerFromContext(ctx)` debug logs on Create/Update request and error paths; surface with `FORMAE_LOG_PLUGINS=debug` per the [observability docs](https://docs.formae.io/en/latest/plugin-sdk/tutorial/15-observability/).

### Testdata (8 files)
- Cluster `version` declared as `new formae.Value { value = "1.33"; strategy = "SetOnce" }`. `"1.28"` is no longer in OVH's enum (OVH rejects with `[version] "1.28" does not match the enum`), and `SetOnce` lets Verify ignore that OVH echoes back the full patch string (`1.33.10-1`).

## Test plan
- [x] `make conformance-test-crud TIMEOUT=20 FORMAE_BINARY=<local> TEST=kube-cluster` — full cluster create/update/destroy cycle (~6 min). Expect [+][+][+][+][+][~][+][X] (OOB Del timeout is the known framework gap).
- [x] `go build ./... && go test -v ./pkg/resources/cloud/kube/...` — unit tests pass.