### PR TITLE
feat(dns): conformance tests for Record and Redirection [WIP]

### DIFF
--- a/pkg/resources/cloud/dns/resources.go
+++ b/pkg/resources/cloud/dns/resources.go
@@ -46,6 +46,8 @@ func init() {
 				SupportsUpdate: true,
 				UpdateMethod:   base.UpdateMethodPut,
 			},
+			RequestTransformer:  recordRequestTransformer,
+			ResponseTransformer: recordResponseTransformer,
 			Operations: []resource.Operation{
 				resource.OperationCreate,
 				resource.OperationRead,
@@ -64,6 +66,8 @@ func init() {
 				SupportsUpdate: true,
 				UpdateMethod:   base.UpdateMethodPut,
 			},
+			RequestTransformer:  redirectionRequestTransformer,
+			ResponseTransformer: redirectionResponseTransformer,
 			Operations: []resource.Operation{
 				resource.OperationCreate,
 				resource.OperationRead,

--- a/pkg/resources/cloud/dns/transformers.go
+++ b/pkg/resources/cloud/dns/transformers.go
@@ -1,0 +1,51 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package dns
+
+import (
+	"github.com/platform-engineering-labs/formae-plugin-ovh/pkg/resources/base"
+)
+
+// renameKey moves props[from] to props[to] if present, deleting the original.
+// No-op if from is absent.
+func renameKey(props map[string]interface{}, from, to string) {
+	if v, ok := props[from]; ok {
+		props[to] = v
+		delete(props, from)
+	}
+}
+
+// The OVH DNS API uses `target` as the property name, but Formae reserves
+// `target` on every Resource for the deployment-target reference. To avoid a
+// collision in pkl, DNS resources declare `recordTarget` / `redirectionTarget`
+// in their schema; these transformers map to/from the OVH API payload.
+
+var recordRequestTransformer = base.RequestTransformerFunc(
+	func(props map[string]interface{}, _ base.TransformContext) (map[string]interface{}, error) {
+		renameKey(props, "recordTarget", "target")
+		return props, nil
+	},
+)
+
+var recordResponseTransformer = base.ResponseTransformerFunc(
+	func(props map[string]interface{}, _ base.TransformContext) map[string]interface{} {
+		renameKey(props, "target", "recordTarget")
+		return props
+	},
+)
+
+var redirectionRequestTransformer = base.RequestTransformerFunc(
+	func(props map[string]interface{}, _ base.TransformContext) (map[string]interface{}, error) {
+		renameKey(props, "redirectionTarget", "target")
+		return props, nil
+	},
+)
+
+var redirectionResponseTransformer = base.ResponseTransformerFunc(
+	func(props map[string]interface{}, _ base.TransformContext) map[string]interface{} {
+		renameKey(props, "target", "redirectionTarget")
+		return props
+	},
+)

--- a/schema/pkl/dns/record.pkl
+++ b/schema/pkl/dns/record.pkl
@@ -33,9 +33,10 @@ open class Record extends formae.Resource {
   @ovh.FieldHint { required = true; createOnly = true }
   fieldType: RecordType
 
-  /// Target value
+  /// Target value (sent to OVH API as `target`; renamed here to avoid collision
+  /// with formae's reserved `target` property on Resource)
   @ovh.FieldHint { required = true }
-  target: String
+  recordTarget: String
 
   /// TTL in seconds
   ttl: Int?

--- a/schema/pkl/dns/redirection.pkl
+++ b/schema/pkl/dns/redirection.pkl
@@ -29,9 +29,10 @@ open class Redirection extends formae.Resource {
   /// Subdomain to redirect
   subDomain: String?
 
-  /// Target URL
+  /// Target URL (sent to OVH API as `target`; renamed here to avoid collision
+  /// with formae's reserved `target` property on Resource)
   @ovh.FieldHint { required = true }
-  target: String
+  redirectionTarget: String
 
   /// Redirection type
   @ovh.FieldHint { required = true }

--- a/testdata/dns-record-replace.pkl
+++ b/testdata/dns-record-replace.pkl
@@ -1,0 +1,25 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+
+import "@ovh/dns/record.pkl" as dnsRecord
+
+import "./config/vars.pkl" as v
+
+forma {
+  v.stack
+  v.target
+
+  new dnsRecord.Record {
+    label = "plugin-sdk-test-dnsrecord"
+    zone = v.dnsZone
+    subDomain = "formae-test-\(v.testRunID)"
+    fieldType = "TXT" // createOnly change forces replacement
+    recordTarget = "v=formae-test"
+    ttl = 300
+  }
+}

--- a/testdata/dns-record-update.pkl
+++ b/testdata/dns-record-update.pkl
@@ -1,0 +1,25 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+
+import "@ovh/dns/record.pkl" as dnsRecord
+
+import "./config/vars.pkl" as v
+
+forma {
+  v.stack
+  v.target
+
+  new dnsRecord.Record {
+    label = "plugin-sdk-test-dnsrecord"
+    zone = v.dnsZone
+    subDomain = "formae-test-\(v.testRunID)"
+    fieldType = "A"
+    recordTarget = "198.51.100.1" // recordTarget is mutable
+    ttl = 600 // ttl is mutable
+  }
+}

--- a/testdata/dns-record.pkl
+++ b/testdata/dns-record.pkl
@@ -1,0 +1,25 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+
+import "@ovh/dns/record.pkl" as dnsRecord
+
+import "./config/vars.pkl" as v
+
+forma {
+  v.stack
+  v.target
+
+  new dnsRecord.Record {
+    label = "plugin-sdk-test-dnsrecord"
+    zone = v.dnsZone
+    subDomain = "formae-test-\(v.testRunID)"
+    fieldType = "A"
+    recordTarget = "192.0.2.1"
+    ttl = 300
+  }
+}

--- a/testdata/dns-redirection-update.pkl
+++ b/testdata/dns-redirection-update.pkl
@@ -1,0 +1,25 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+
+import "@ovh/dns/redirection.pkl"
+
+import "./config/vars.pkl" as v
+
+forma {
+  v.stack
+  v.target
+
+  new redirection.Redirection {
+    label = "plugin-sdk-test-dnsredirection"
+    zone = v.dnsZone
+    subDomain = "formae-redir-\(v.testRunID)"
+    redirectionTarget = "https://example.org" // redirectionTarget is mutable
+    type = "visible" // type is mutable
+    description = "Formae conformance test redirection - updated" // description is mutable
+  }
+}

--- a/testdata/dns-redirection.pkl
+++ b/testdata/dns-redirection.pkl
@@ -1,0 +1,25 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+
+import "@ovh/dns/redirection.pkl"
+
+import "./config/vars.pkl" as v
+
+forma {
+  v.stack
+  v.target
+
+  new redirection.Redirection {
+    label = "plugin-sdk-test-dnsredirection"
+    zone = v.dnsZone
+    subDomain = "formae-redir-\(v.testRunID)"
+    redirectionTarget = "https://example.com"
+    type = "visiblePermanent"
+    description = "Formae conformance test redirection"
+  }
+}


### PR DESCRIPTION
## Summary

- Schema: rename `target` -> `recordTarget` / `redirectionTarget` on `OVH::DNS::Record` and `OVH::DNS::Redirection` to avoid collision with formae's reserved `target` property on `Resource` (which caused every DNS forma to fail PKL evaluation with `Cannot find property 'label' in object of type 'String'` during `FormaRender.hasTarget`).
- Plugin: wire up request/response transformers in `pkg/resources/cloud/dns/transformers.go` that map the pkl-side property back to the OVH API's `target` field on POST/PUT, and the reverse on GET, so the OVH contract is unchanged.
- Testdata: add `dns-record(.pkl|-update|-replace)` and `dns-redirection(.pkl|-update)` conformance inputs.

## Why this is a draft

The tests cannot yet execute against my sandbox tenant because:
1. The OVH application key used for conformance runs lacks `/domain/*` scope (`/domain/zone` currently returns `403 Forbidden: \"This call has not been granted\"`).
2. `OVH_DNS_ZONE` needs to point at a zone the tenant actually owns (default `example.com` is not usable).

Once an API key with DNS grants is available and a real zone is exported via `OVH_DNS_ZONE`, the conformance runner should exercise these resources end-to-end. The plugin-side changes are self-contained and should not require further work; only infra/credential access is blocking verification.

## Test plan

- [ ] Conformance: `make conformance-test-crud TEST=dns-record`
- [ ] Conformance: `make conformance-test-crud TEST=dns-redirection`
- [ ] Verify Read path returns `recordTarget` / `redirectionTarget` (not `target`) so formae's target-resolution layer keeps working.