### PR TITLE
Switch to orbital-based distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+# © 2026 Platform Engineering Labs Inc.
+# SPDX-License-Identifier: FSL-1.1-ALv2
+
+name: release
+on:
+  push:
+    tags:
+      - '[0-9]*'
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          GH_TOKEN: ${{ secrets.HUB_DISPATCH_PAT }}
+        run: |
+          gh workflow run plugin-build.yml \
+            -R platform-engineering-labs/formae-actions \
+            --ref main \
+            -f plugin-name=ovh \
+            -f plugin-repo=$GITHUB_REPOSITORY \
+            -f ref=$GITHUB_REF_NAME

--- a/Opkgfile
+++ b/Opkgfile
@@ -1,0 +1,39 @@
+/*
+ * © 2026 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "orbital:/opkg.pkl"
+
+import "orbital:/requirement.pkl"
+import "pkl:semver"
+import "./formae-plugin.pkl" as plugin
+
+name        = plugin.name
+version     = semver.Version(plugin.version)
+publisher   = read("env:OPS_PUBLISHER")
+originator  = read("env:OPS_ORIGINATOR")
+license     = plugin.license
+summary     = if (plugin.hasProperty("summary")) plugin.summary else plugin.name
+description = if (plugin.hasProperty("description")) plugin.description else plugin.summary
+
+requirements = new Listing<requirement.Requirement> {
+  new {
+    name     = "formae"
+    method   = "depends"
+    operator = "GTE"
+    version  = semver.Version(plugin.minFormaeVersion)
+  }
+}
+
+metadata {
+  ["display"] {
+    ["kind"]     = "plugin"
+    ["category"] = if (plugin.hasProperty("category")) plugin.category else "other"
+  }
+  ["plugin"] {
+    ["type"]      = if (plugin.hasProperty("type")) plugin.type else "resource"
+    ["namespace"] = plugin.namespace
+  }
+}

--- a/formae-plugin.pkl
+++ b/formae-plugin.pkl
@@ -7,7 +7,9 @@
 name = "ovh"
 version = "0.1.4"
 namespace = "OVH"
+summary = "OVHcloud resource plugin"
 description = "OVH Cloud resource plugin for Formae"
+category = "cloud"
 license = "FSL-1.1-ALv2"
 minFormaeVersion = "0.84.0"
 


### PR DESCRIPTION
Migrates this plugin to the centralized build pipeline defined by RFC-0033. Mirrors formae-plugin-aws#53. Wrapper inactive until HUB_DISPATCH_PAT secret is set.