### PR TITLE
fix(network): drop duplicate SecurityGroup OVH registration so OpenStack wins

### DIFF
--- a/pkg/resources/cloud/network/resources.go
+++ b/pkg/resources/cloud/network/resources.go
@@ -20,9 +20,10 @@ const (
 	PrivateNetworkResourceType = "OVH::Network::PrivateNetwork"
 	//SubnetResourceType         = "OVH::Network::Subnet"
 	PrivateSubnetResourceType = "OVH::Network::PrivateSubnet"
-	FloatingIPResourceType    = "OVH::Network::FloatingIP"
-	SecurityGroupResourceType = "OVH::Network::SecurityGroup"
-	GatewayResourceType       = "OVH::Network::Gateway"
+	FloatingIPResourceType = "OVH::Network::FloatingIP"
+	// SecurityGroup ("OVH::Network::SecurityGroup") is registered via the
+	// OpenStack transport — see pkg/resources/openstack/resources/network/securitygroup.go.
+	GatewayResourceType = "OVH::Network::Gateway"
 )
 
 var cloudNetworkRegistry *base.ResourceRegistry
@@ -159,22 +160,12 @@ func init() {
 		// - Delete: DELETE /cloud/project/{serviceName}/region/{regionName}/floatingip/{floatingIpId}
 		// - List:   GET /cloud/project/{serviceName}/region/{regionName}/floatingip
 
-		// Security Group
-		{
-			ResourceType: SecurityGroupResourceType,
-			ResourceConfig: base.ResourceConfig{
-				ResourceType:   "instance/group",
-				Scope:          &base.ScopeConfig{Type: base.ScopeProject},
-				SupportsUpdate: true,
-			},
-			Operations: []resource.Operation{
-				resource.OperationCreate,
-				resource.OperationRead,
-				resource.OperationUpdate,
-				resource.OperationDelete,
-				resource.OperationList,
-			},
-		},
+		// NOTE: SecurityGroup is registered via the OpenStack transport in
+		// pkg/resources/openstack/resources/network/securitygroup.go. The OVH
+		// REST endpoint /cloud/project/{serviceName}/instance/group is a
+		// legacy non-regional path that returns HTTP 500 for newer projects;
+		// the Neutron path is the supported one.
+		//
 		// NOTE: Gateway is registered separately in gateway.go with custom path builder
 		// because Create path differs from Read/Delete/List path:
 		// - Create: POST /cloud/project/{serviceName}/region/{regionName}/network/{networkId}/subnet/{subnetId}/gateway


### PR DESCRIPTION
## Summary

`OVH::Network::SecurityGroup` was registered twice against the same shared `registrations` map:

- `pkg/resources/cloud/network/resources.go:164` — OVH REST path `/cloud/project/{id}/instance/group`
- `pkg/resources/openstack/resources/network/securitygroup.go:48` — Neutron-backed via the OpenStack transport

`init()` order is non-deterministic but tied; on the current build the OVH-side registration wins and overwrites the OpenStack one in the map. The OVH endpoint returns HTTP 500 (`INTERNAL_ERROR: Internal server error`) on current cloud projects — it's a legacy non-regional path — so every conformance run on `main` fails the `security-group` matrix job, e.g. https://github.com/platform-engineering-labs/formae-plugin-ovh/actions/runs/25156370561/job/73749967677.

## Change

- Remove the OVH-side `RegisterAll` entry for SecurityGroup in `pkg/resources/cloud/network/resources.go`.
- Drop the now-unused `SecurityGroupResourceType` constant; the OpenStack package owns its own `ResourceTypeSecurityGroup`.
- Add a comment pointing maintainers at the OpenStack registration path so the duplicate doesn't get reintroduced.

`SecurityGroupRule` was already on the OpenStack transport, so this aligns the pair on the same backend.

## Test plan

- [x] `make build`
- [ ] CI: `conformance-crud-tests (security-group)` goes green
- [ ] CI: `conformance-crud-tests (security-group-rule)` goes green (was cascading)