### PR TITLE
fix(discovery): inject URL-only required fields so discovered resources land in inventory

### DIFF
--- a/pkg/resources/base/base_resource.go
+++ b/pkg/resources/base/base_resource.go
@@ -29,6 +29,42 @@ type BaseResource struct {
 	Client              TransportClient
 }
 
+// injectURLFields copies values from pathCtx back into the response body for
+// fields declared in ResourceConfig.URLFieldInjection. The returned map is
+// either the (possibly-modified) input or a new map when input was nil and
+// any field needs injecting.
+func (b *BaseResource) injectURLFields(props map[string]interface{}, pathCtx PathContext) map[string]interface{} {
+	if len(b.ResourceConfig.URLFieldInjection) == 0 {
+		return props
+	}
+	if props == nil {
+		props = make(map[string]interface{})
+	}
+	for bodyField, ctxField := range b.ResourceConfig.URLFieldInjection {
+		var v string
+		switch ctxField {
+		case "Project":
+			v = pathCtx.Project
+		case "Region":
+			v = pathCtx.Region
+		case "Zone":
+			v = pathCtx.Zone
+		case "Location":
+			v = pathCtx.Location
+		case "Engine":
+			v = pathCtx.Engine
+		case "ParentResource":
+			v = pathCtx.ParentResource
+		case "ResourceName":
+			v = pathCtx.ResourceName
+		}
+		if v != "" {
+			props[bodyField] = v
+		}
+	}
+	return props
+}
+
 // mapKeys returns sorted map keys for stable debug logging.
 func mapKeys(m map[string]interface{}) []string {
 	keys := make([]string, 0, len(m))
@@ -163,6 +199,7 @@ func (b *BaseResource) Create(ctx context.Context, request *resource.CreateReque
 		transformCtx := b.buildTransformContext(ctx, pathCtx, resource.OperationCreate)
 		responseProps = b.ResponseTransformer.Transform(responseProps, transformCtx)
 	}
+	responseProps = b.injectURLFields(responseProps, pathCtx)
 
 	propsJSON, _ := json.Marshal(responseProps)
 
@@ -254,6 +291,7 @@ func (b *BaseResource) Read(ctx context.Context, request *resource.ReadRequest) 
 		transformCtx := b.buildTransformContext(ctx, pathCtx, resource.OperationRead)
 		responseProps = b.ResponseTransformer.Transform(responseProps, transformCtx)
 	}
+	responseProps = b.injectURLFields(responseProps, pathCtx)
 
 	propsJSON, _ := json.Marshal(responseProps)
 
@@ -346,6 +384,7 @@ func (b *BaseResource) Update(ctx context.Context, request *resource.UpdateReque
 		transformCtx := b.buildTransformContext(ctx, pathCtx, resource.OperationUpdate)
 		responseProps = b.ResponseTransformer.Transform(responseProps, transformCtx)
 	}
+	responseProps = b.injectURLFields(responseProps, pathCtx)
 
 	propsJSON, _ := json.Marshal(responseProps)
 
@@ -768,6 +807,7 @@ func (b *BaseResource) Status(ctx context.Context, request *resource.StatusReque
 		transformCtx := b.buildTransformContext(ctx, pathCtx, resource.OperationCheckStatus)
 		responseProps = b.ResponseTransformer.Transform(responseProps, transformCtx)
 	}
+	responseProps = b.injectURLFields(responseProps, pathCtx)
 
 	propsJSON, _ := json.Marshal(responseProps)
 	return &resource.StatusResult{

--- a/pkg/resources/base/resource_config.go
+++ b/pkg/resources/base/resource_config.go
@@ -75,4 +75,13 @@ type ResourceConfig struct {
 	// formae owns the polling cadence and the plugin avoids hard-coded
 	// timeouts.
 	AsyncDelete bool
+
+	// URLFieldInjection injects PathContext fields back into the response body
+	// when those fields are required by the schema but only present in the URL
+	// (e.g. serviceName, region). Map keys are body field names; values are
+	// PathContext field names ("Project", "Region", "Zone", "Location",
+	// "Engine", "ParentResource"). Without this, formae's resource_persister
+	// silently drops discovered resources whose required schema fields are
+	// URL-only.
+	URLFieldInjection map[string]string
 }

--- a/pkg/resources/cloud/compute/resources.go
+++ b/pkg/resources/cloud/compute/resources.go
@@ -68,6 +68,11 @@ func init() {
 				UpdateMethod:     base.UpdateMethodPut,
 				AsyncDelete:      true,
 				DeletingStatuses: []string{"DELETED", "DELETING"},
+				// `region` is a URL parameter; OVH's GET response uses
+				// `region` already, but Read derives it from the URL only.
+				URLFieldInjection: map[string]string{
+					"region": "Region",
+				},
 			},
 			ResponseTransformer: instanceTransformer,
 			StatusChecker:       instanceStatusChecker,
@@ -114,6 +119,9 @@ func init() {
 				SupportsUpdate:   true,
 				UpdateMethod:     base.UpdateMethodPut,
 				DeletingStatuses: []string{"deleting", "deleted"},
+				URLFieldInjection: map[string]string{
+					"region": "Region",
+				},
 			},
 			StatusChecker: volumeStatusChecker,
 			Operations: []resource.Operation{

--- a/pkg/resources/cloud/compute/snapshot.go
+++ b/pkg/resources/cloud/compute/snapshot.go
@@ -109,6 +109,11 @@ func init() {
 				PropertyName:   "volume_id",
 			},
 			SupportsUpdate: false, // Snapshots are immutable
+			// Schema requires volume_id; OVH's GET response doesn't return it
+			// because it's a URL parameter. Inject from the parent segment.
+			URLFieldInjection: map[string]string{
+				"volume_id": "ParentResource",
+			},
 		},
 		RequestTransformer: volumeSnapshotTransformer,
 		Operations: []resource.Operation{

--- a/pkg/resources/cloud/database/nested.go
+++ b/pkg/resources/cloud/database/nested.go
@@ -122,6 +122,14 @@ func (p *nestedProvisioner) Read(ctx context.Context, request *resource.ReadRequ
 		return &resource.ReadResult{ErrorCode: resource.OperationErrorCodeServiceInternalError}, nil
 	}
 
+	// serviceName, engine, and clusterId are URL parameters, not in the OVH API
+	// body. Inject them so discovery sync passes formae's required-field validation.
+	if response.Body != nil {
+		response.Body["serviceName"] = project
+		response.Body["engine"] = engine
+		response.Body["clusterId"] = clusterID
+	}
+
 	propsJSON, _ := json.Marshal(response.Body)
 	return &resource.ReadResult{Properties: string(propsJSON)}, nil
 }

--- a/pkg/resources/cloud/database/service.go
+++ b/pkg/resources/cloud/database/service.go
@@ -105,6 +105,13 @@ func (p *serviceProvisioner) Read(ctx context.Context, request *resource.ReadReq
 		return &resource.ReadResult{ErrorCode: resource.OperationErrorCodeServiceInternalError}, nil
 	}
 
+	// serviceName and engine are URL parameters, not in the OVH API body.
+	// Inject them so discovery sync passes formae's required-field validation.
+	if response.Body != nil {
+		response.Body["serviceName"] = project
+		response.Body["engine"] = engine
+	}
+
 	propsJSON, _ := json.Marshal(response.Body)
 	return &resource.ReadResult{Properties: string(propsJSON)}, nil
 }
@@ -250,6 +257,12 @@ func (p *serviceProvisioner) Status(ctx context.Context, request *resource.Statu
 				NativeID:        request.NativeID,
 			},
 		}, nil
+	}
+
+	// Inject URL-only fields so ResourceProperties satisfies required-field validation.
+	if response.Body != nil {
+		response.Body["serviceName"] = project
+		response.Body["engine"] = engine
 	}
 
 	propsJSON, _ := json.Marshal(response.Body)

--- a/pkg/resources/cloud/dns/resources.go
+++ b/pkg/resources/cloud/dns/resources.go
@@ -45,6 +45,9 @@ func init() {
 				Scope:          &base.ScopeConfig{Type: base.ScopeZone},
 				SupportsUpdate: true,
 				UpdateMethod:   base.UpdateMethodPut,
+				URLFieldInjection: map[string]string{
+					"zone": "Zone",
+				},
 			},
 			Operations: []resource.Operation{
 				resource.OperationCreate,
@@ -63,6 +66,9 @@ func init() {
 				Scope:          &base.ScopeConfig{Type: base.ScopeZone},
 				SupportsUpdate: true,
 				UpdateMethod:   base.UpdateMethodPut,
+				URLFieldInjection: map[string]string{
+					"zone": "Zone",
+				},
 			},
 			Operations: []resource.Operation{
 				resource.OperationCreate,

--- a/pkg/resources/cloud/kube/cluster.go
+++ b/pkg/resources/cloud/kube/cluster.go
@@ -106,6 +106,13 @@ func (p *clusterProvisioner) Read(ctx context.Context, request *resource.ReadReq
 		return &resource.ReadResult{ErrorCode: resource.OperationErrorCodeServiceInternalError}, nil
 	}
 
+	// serviceName is a URL parameter, not part of the OVH API body. Inject it
+	// from the native ID so the discovered resource passes formae's required-
+	// field validation (cluster.pkl declares serviceName required).
+	if response.Body != nil {
+		response.Body["serviceName"] = project
+	}
+
 	propsJSON, _ := json.Marshal(response.Body)
 	return &resource.ReadResult{Properties: string(propsJSON)}, nil
 }
@@ -269,6 +276,12 @@ func (p *clusterProvisioner) Status(ctx context.Context, request *resource.Statu
 				NativeID:        request.NativeID,
 			},
 		}, nil
+	}
+
+	// Inject serviceName so it's present in ResourceProperties — required field
+	// in the schema, not returned by the OVH API body.
+	if response.Body != nil {
+		response.Body["serviceName"] = project
 	}
 
 	propsJSON, _ := json.Marshal(response.Body)

--- a/pkg/resources/cloud/kube/helpers.go
+++ b/pkg/resources/cloud/kube/helpers.go
@@ -5,6 +5,7 @@
 package kube
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -12,6 +13,27 @@ import (
 	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
 	ovhtransport "github.com/platform-engineering-labs/formae-plugin-ovh/pkg/transport/ovh"
 )
+
+// listClusterIDs returns all kube cluster IDs for a project. Used by child
+// resources (NodePool, IpRestriction, Oidc) during discovery — formae calls
+// their List with empty AdditionalProperties, so they must enumerate parents
+// themselves rather than rely on a kubeId being passed in.
+func listClusterIDs(ctx context.Context, client *ovhtransport.Client, project string) ([]string, error) {
+	resp, err := client.Do(ctx, ovhtransport.RequestOptions{
+		Method: "GET",
+		Path:   fmt.Sprintf("/cloud/project/%s/kube", project),
+	})
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]string, 0, len(resp.BodyArray))
+	for _, item := range resp.BodyArray {
+		if id, ok := item.(string); ok {
+			ids = append(ids, id)
+		}
+	}
+	return ids, nil
+}
 
 // extractProject extracts project from target config or props
 func extractProject(targetConfig json.RawMessage, props map[string]interface{}) string {

--- a/pkg/resources/cloud/kube/iprestriction.go
+++ b/pkg/resources/cloud/kube/iprestriction.go
@@ -176,22 +176,36 @@ func (p *ipRestrictionProvisioner) Delete(ctx context.Context, request *resource
 	}, nil
 }
 
+// List enumerates IP restrictions across the project. Discovery calls List
+// with empty AdditionalProperties, so when no kubeId is supplied we iterate
+// every cluster in the project.
 func (p *ipRestrictionProvisioner) List(ctx context.Context, request *resource.ListRequest) (*resource.ListResult, error) {
 	project := extractProjectFromAdditional(request.TargetConfig, request.AdditionalProperties)
-	kubeID := request.AdditionalProperties["kubeId"]
-
-	if project == "" || kubeID == "" {
+	if project == "" {
 		return &resource.ListResult{NativeIDs: nil}, nil
 	}
 
-	currentIPs, err := p.listIPRestrictions(ctx, project, kubeID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list IP restrictions: %w", err)
+	kubeIDs := []string{}
+	if k := request.AdditionalProperties["kubeId"]; k != "" {
+		kubeIDs = append(kubeIDs, k)
+	} else {
+		all, err := listClusterIDs(ctx, p.client, project)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list kube clusters: %w", err)
+		}
+		kubeIDs = all
 	}
 
-	nativeIDs := make([]string, 0, len(currentIPs))
-	for _, ip := range currentIPs {
-		nativeIDs = append(nativeIDs, fmt.Sprintf("%s/%s/%s", project, kubeID, ip))
+	var nativeIDs []string
+	for _, kubeID := range kubeIDs {
+		currentIPs, err := p.listIPRestrictions(ctx, project, kubeID)
+		if err != nil {
+			// Cluster gone or transient — skip rather than fail the whole listing.
+			continue
+		}
+		for _, ip := range currentIPs {
+			nativeIDs = append(nativeIDs, fmt.Sprintf("%s/%s/%s", project, kubeID, ip))
+		}
 	}
 
 	return &resource.ListResult{NativeIDs: nativeIDs}, nil

--- a/pkg/resources/cloud/kube/iprestriction.go
+++ b/pkg/resources/cloud/kube/iprestriction.go
@@ -69,7 +69,11 @@ func (p *ipRestrictionProvisioner) Create(ctx context.Context, request *resource
 	}
 
 	nativeID := fmt.Sprintf("%s/%s/%s", project, kubeID, ip)
-	propsJSON, _ := json.Marshal(map[string]interface{}{"ip": ip})
+	propsJSON, _ := json.Marshal(map[string]interface{}{
+		"ip":          ip,
+		"serviceName": project,
+		"kubeId":      kubeID,
+	})
 
 	return &resource.CreateResult{
 		ProgressResult: &resource.ProgressResult{
@@ -99,7 +103,13 @@ func (p *ipRestrictionProvisioner) Read(ctx context.Context, request *resource.R
 
 	for _, existing := range currentIPs {
 		if existing == ip {
-			propsJSON, _ := json.Marshal(map[string]interface{}{"ip": ip})
+			// Include URL-only fields (serviceName, kubeId) so discovered
+			// resources pass formae's required-field validation.
+			propsJSON, _ := json.Marshal(map[string]interface{}{
+				"ip":          ip,
+				"serviceName": project,
+				"kubeId":      kubeID,
+			})
 			return &resource.ReadResult{Properties: string(propsJSON)}, nil
 		}
 	}

--- a/pkg/resources/cloud/kube/nodepool.go
+++ b/pkg/resources/cloud/kube/nodepool.go
@@ -108,9 +108,16 @@ func (p *nodePoolProvisioner) Read(ctx context.Context, request *resource.ReadRe
 
 	// serviceName and kubeId are URL parameters, not in the OVH API body. Inject
 	// them so discovery sync passes formae's required-field validation.
+	// OVH returns the flavor as "flavor" but the schema's required field is
+	// "flavorName" — mirror it so validation passes on discovery.
 	if response.Body != nil {
 		response.Body["serviceName"] = project
 		response.Body["kubeId"] = kubeID
+		if _, has := response.Body["flavorName"]; !has {
+			if f, ok := response.Body["flavor"].(string); ok && f != "" {
+				response.Body["flavorName"] = f
+			}
+		}
 	}
 
 	propsJSON, _ := json.Marshal(response.Body)
@@ -206,28 +213,47 @@ func (p *nodePoolProvisioner) Delete(ctx context.Context, request *resource.Dele
 	}, nil
 }
 
+// List enumerates node pools across the project. Discovery calls List with
+// empty AdditionalProperties, so when no kubeId is supplied we iterate every
+// cluster in the project.
 func (p *nodePoolProvisioner) List(ctx context.Context, request *resource.ListRequest) (*resource.ListResult, error) {
 	project := extractProjectFromAdditional(request.TargetConfig, request.AdditionalProperties)
-	kubeID := request.AdditionalProperties["kubeId"]
-
-	if project == "" || kubeID == "" {
+	if project == "" {
 		return &resource.ListResult{NativeIDs: nil}, nil
 	}
 
-	url := fmt.Sprintf("/cloud/project/%s/kube/%s/nodepool", project, kubeID)
-
-	response, err := p.client.Do(ctx, ovhtransport.RequestOptions{
-		Method: "GET",
-		Path:   url,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to list node pools: %w", err)
+	kubeIDs := []string{}
+	if k := request.AdditionalProperties["kubeId"]; k != "" {
+		kubeIDs = append(kubeIDs, k)
+	} else {
+		all, err := listClusterIDs(ctx, p.client, project)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list kube clusters: %w", err)
+		}
+		kubeIDs = all
 	}
 
 	var nativeIDs []string
-	for _, item := range response.BodyArray {
-		if id, ok := item.(string); ok {
-			nativeIDs = append(nativeIDs, fmt.Sprintf("%s/%s/%s", project, kubeID, id))
+	for _, kubeID := range kubeIDs {
+		response, err := p.client.Do(ctx, ovhtransport.RequestOptions{
+			Method: "GET",
+			Path:   fmt.Sprintf("/cloud/project/%s/kube/%s/nodepool", project, kubeID),
+		})
+		if err != nil {
+			// Cluster gone or transient — skip rather than fail the whole listing.
+			continue
+		}
+		// OVH nodepool list may return either an array of ID strings or an array
+		// of full nodepool objects depending on the API version. Handle both.
+		for _, item := range response.BodyArray {
+			switch v := item.(type) {
+			case string:
+				nativeIDs = append(nativeIDs, fmt.Sprintf("%s/%s/%s", project, kubeID, v))
+			case map[string]interface{}:
+				if id, ok := v["id"].(string); ok && id != "" {
+					nativeIDs = append(nativeIDs, fmt.Sprintf("%s/%s/%s", project, kubeID, id))
+				}
+			}
 		}
 	}
 
@@ -294,9 +320,15 @@ func (p *nodePoolProvisioner) Status(ctx context.Context, request *resource.Stat
 	}
 
 	// Inject URL-only fields so ResourceProperties satisfies required-field validation.
+	// flavorName mirrors OVH's "flavor" since the schema declares flavorName required.
 	if response.Body != nil {
 		response.Body["serviceName"] = project
 		response.Body["kubeId"] = kubeID
+		if _, has := response.Body["flavorName"]; !has {
+			if f, ok := response.Body["flavor"].(string); ok && f != "" {
+				response.Body["flavorName"] = f
+			}
+		}
 	}
 
 	propsJSON, _ := json.Marshal(response.Body)

--- a/pkg/resources/cloud/kube/nodepool.go
+++ b/pkg/resources/cloud/kube/nodepool.go
@@ -105,6 +105,14 @@ func (p *nodePoolProvisioner) Read(ctx context.Context, request *resource.ReadRe
 	}
 
 	log.Debug("kube nodepool read response", "body", response.Body)
+
+	// serviceName and kubeId are URL parameters, not in the OVH API body. Inject
+	// them so discovery sync passes formae's required-field validation.
+	if response.Body != nil {
+		response.Body["serviceName"] = project
+		response.Body["kubeId"] = kubeID
+	}
+
 	propsJSON, _ := json.Marshal(response.Body)
 	return &resource.ReadResult{Properties: string(propsJSON)}, nil
 }
@@ -283,6 +291,12 @@ func (p *nodePoolProvisioner) Status(ctx context.Context, request *resource.Stat
 				NativeID:        request.NativeID,
 			},
 		}, nil
+	}
+
+	// Inject URL-only fields so ResourceProperties satisfies required-field validation.
+	if response.Body != nil {
+		response.Body["serviceName"] = project
+		response.Body["kubeId"] = kubeID
 	}
 
 	propsJSON, _ := json.Marshal(response.Body)

--- a/pkg/resources/cloud/kube/oidc.go
+++ b/pkg/resources/cloud/kube/oidc.go
@@ -112,6 +112,13 @@ func (p *oidcProvisioner) Read(ctx context.Context, request *resource.ReadReques
 		return &resource.ReadResult{ErrorCode: resource.OperationErrorCodeNotFound}, nil
 	}
 
+	// serviceName and kubeId are URL parameters, not in the OVH API body. Inject
+	// them so discovery sync passes formae's required-field validation.
+	if response.Body != nil {
+		response.Body["serviceName"] = project
+		response.Body["kubeId"] = kubeID
+	}
+
 	propsJSON, _ := json.Marshal(response.Body)
 	return &resource.ReadResult{Properties: string(propsJSON)}, nil
 }
@@ -304,6 +311,11 @@ func (p *oidcProvisioner) Status(ctx context.Context, request *resource.StatusRe
 	})
 	var propsJSON []byte
 	if err == nil {
+		// Inject URL-only fields so ResourceProperties satisfies required-field validation.
+		if oidc.Body != nil {
+			oidc.Body["serviceName"] = project
+			oidc.Body["kubeId"] = kubeID
+		}
 		propsJSON, _ = json.Marshal(oidc.Body)
 	}
 

--- a/pkg/resources/cloud/kube/oidc.go
+++ b/pkg/resources/cloud/kube/oidc.go
@@ -214,34 +214,46 @@ func (p *oidcProvisioner) Delete(ctx context.Context, request *resource.DeleteRe
 	}, nil
 }
 
+// List enumerates OIDC integrations across the project. Discovery calls List
+// with empty AdditionalProperties, so when no kubeId is supplied we iterate
+// every cluster in the project. OIDC is a singleton per cluster — at most one
+// native ID per cluster.
 func (p *oidcProvisioner) List(ctx context.Context, request *resource.ListRequest) (*resource.ListResult, error) {
 	project := extractProjectFromAdditional(request.TargetConfig, request.AdditionalProperties)
-	kubeID := request.AdditionalProperties["kubeId"]
-
-	if project == "" || kubeID == "" {
+	if project == "" {
 		return &resource.ListResult{NativeIDs: nil}, nil
 	}
 
-	url := fmt.Sprintf("/cloud/project/%s/kube/%s/openIdConnect", project, kubeID)
-
-	response, err := p.client.Do(ctx, ovhtransport.RequestOptions{
-		Method: "GET",
-		Path:   url,
-	})
-	if err != nil {
-		// No OIDC configured (or 404) — treat as empty list
-		return &resource.ListResult{NativeIDs: nil}, nil
+	kubeIDs := []string{}
+	if k := request.AdditionalProperties["kubeId"]; k != "" {
+		kubeIDs = append(kubeIDs, k)
+	} else {
+		all, err := listClusterIDs(ctx, p.client, project)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list kube clusters: %w", err)
+		}
+		kubeIDs = all
 	}
 
-	// OVH returns 200 with an empty body when OIDC is not configured; only
-	// report a native ID when an integration is actually present.
-	if clientID, _ := response.Body["clientId"].(string); clientID == "" {
-		return &resource.ListResult{NativeIDs: nil}, nil
+	var nativeIDs []string
+	for _, kubeID := range kubeIDs {
+		response, err := p.client.Do(ctx, ovhtransport.RequestOptions{
+			Method: "GET",
+			Path:   fmt.Sprintf("/cloud/project/%s/kube/%s/openIdConnect", project, kubeID),
+		})
+		if err != nil {
+			// No OIDC configured (or 404) — skip this cluster.
+			continue
+		}
+		// OVH returns 200 with an empty body when OIDC is not configured; only
+		// report a native ID when an integration is actually present.
+		if clientID, _ := response.Body["clientId"].(string); clientID == "" {
+			continue
+		}
+		nativeIDs = append(nativeIDs, fmt.Sprintf("%s/%s", project, kubeID))
 	}
 
-	return &resource.ListResult{
-		NativeIDs: []string{fmt.Sprintf("%s/%s", project, kubeID)},
-	}, nil
+	return &resource.ListResult{NativeIDs: nativeIDs}, nil
 }
 
 // Status polls the parent cluster's status. OIDC has no state of its own; the

--- a/pkg/resources/cloud/network/private_subnet.go
+++ b/pkg/resources/cloud/network/private_subnet.go
@@ -121,6 +121,7 @@ func (p *PrivateSubnetProvisioner) Create(ctx context.Context, request *resource
 			}
 
 			result := transformSubnetResponse(subnet, networkID)
+			result["networkId"] = networkID
 			propsJSON, err := json.Marshal(result)
 			if err != nil {
 				return privateSubnetCreateFailure(resource.OperationErrorCodeServiceInternalError, fmt.Sprintf("failed to marshal properties: %v", err)), nil
@@ -199,7 +200,11 @@ func (p *PrivateSubnetProvisioner) Read(ctx context.Context, request *resource.R
 			// API returns: {id, cidr, gatewayIp, ipPools: [{dhcp, end, network, region, start}]}
 			// Schema expects: {id, network_id, region, network, dhcp, noGateway, start, end}
 			result := transformSubnetResponse(subnet, networkID)
-
+			// Inject URL-only required fields (networkId is in URL, schema
+			// declares it required). transformSubnetResponse already keys
+			// it as `network_id` via outputField; also expose it under the
+			// PKL field name so required-field validation passes.
+			result["networkId"] = networkID
 			propsJSON, err := json.Marshal(result)
 			if err != nil {
 				return &resource.ReadResult{

--- a/pkg/resources/cloud/registry/iprestriction.go
+++ b/pkg/resources/cloud/registry/iprestriction.go
@@ -61,6 +61,9 @@ func (p *ipRestrictionProvisioner) Create(ctx context.Context, request *resource
 		if existingIP, _ := existing["ipBlock"].(string); existingIP == ipBlock {
 			// Already exists
 			nativeID := fmt.Sprintf("%s/%s/%s/%s", project, registryID, restrictionType, ipBlock)
+			existing["serviceName"] = project
+			existing["registryId"] = registryID
+			existing["type"] = restrictionType
 			propsJSON, _ := json.Marshal(existing)
 			return &resource.CreateResult{
 				ProgressResult: &resource.ProgressResult{
@@ -91,6 +94,9 @@ func (p *ipRestrictionProvisioner) Create(ctx context.Context, request *resource
 	// Native ID: project/registryId/type/ipBlock
 	nativeID := fmt.Sprintf("%s/%s/%s/%s", project, registryID, restrictionType, ipBlock)
 
+	newRestriction["serviceName"] = project
+	newRestriction["registryId"] = registryID
+	newRestriction["type"] = restrictionType
 	propsJSON, _ := json.Marshal(newRestriction)
 
 	return &resource.CreateResult{
@@ -122,6 +128,12 @@ func (p *ipRestrictionProvisioner) Read(ctx context.Context, request *resource.R
 	// Find the specific IP
 	for _, existing := range currentIPs {
 		if existingIP, _ := existing["ipBlock"].(string); existingIP == ipBlock {
+			// serviceName, registryId, and type are URL parameters, not in the
+			// OVH API body. Inject them so discovery sync passes formae's
+			// required-field validation.
+			existing["serviceName"] = project
+			existing["registryId"] = registryID
+			existing["type"] = restrictionType
 			propsJSON, _ := json.Marshal(existing)
 			return &resource.ReadResult{Properties: string(propsJSON)}, nil
 		}

--- a/pkg/resources/cloud/registry/oidc.go
+++ b/pkg/resources/cloud/registry/oidc.go
@@ -93,6 +93,13 @@ func (p *oidcProvisioner) Read(ctx context.Context, request *resource.ReadReques
 		return &resource.ReadResult{ErrorCode: resource.OperationErrorCodeServiceInternalError}, nil
 	}
 
+	// serviceName and registryId are URL parameters, not in the OVH API body.
+	// Inject them so discovery sync passes formae's required-field validation.
+	if response.Body != nil {
+		response.Body["serviceName"] = project
+		response.Body["registryId"] = registryID
+	}
+
 	propsJSON, _ := json.Marshal(response.Body)
 	return &resource.ReadResult{Properties: string(propsJSON)}, nil
 }

--- a/pkg/resources/cloud/registry/registry.go
+++ b/pkg/resources/cloud/registry/registry.go
@@ -97,6 +97,12 @@ func (p *registryProvisioner) Read(ctx context.Context, request *resource.ReadRe
 		return &resource.ReadResult{ErrorCode: resource.OperationErrorCodeServiceInternalError}, nil
 	}
 
+	// serviceName is a URL parameter, not in the OVH API body. Inject it so
+	// discovery sync passes formae's required-field validation.
+	if response.Body != nil {
+		response.Body["serviceName"] = project
+	}
+
 	propsJSON, _ := json.Marshal(response.Body)
 	return &resource.ReadResult{Properties: string(propsJSON)}, nil
 }
@@ -241,6 +247,11 @@ func (p *registryProvisioner) Status(ctx context.Context, request *resource.Stat
 				NativeID:        request.NativeID,
 			},
 		}, nil
+	}
+
+	// Inject URL-only field so ResourceProperties satisfies required-field validation.
+	if response.Body != nil {
+		response.Body["serviceName"] = project
 	}
 
 	propsJSON, _ := json.Marshal(response.Body)

--- a/pkg/resources/cloud/registry/user.go
+++ b/pkg/resources/cloud/registry/user.go
@@ -99,6 +99,13 @@ func (p *userProvisioner) Read(ctx context.Context, request *resource.ReadReques
 		return &resource.ReadResult{ErrorCode: resource.OperationErrorCodeServiceInternalError}, nil
 	}
 
+	// serviceName and registryId are URL parameters, not in the OVH API body.
+	// Inject them so discovery sync passes formae's required-field validation.
+	if response.Body != nil {
+		response.Body["serviceName"] = project
+		response.Body["registryId"] = registryID
+	}
+
 	propsJSON, _ := json.Marshal(response.Body)
 	return &resource.ReadResult{Properties: string(propsJSON)}, nil
 }

--- a/pkg/resources/cloud/storage/resources.go
+++ b/pkg/resources/cloud/storage/resources.go
@@ -45,6 +45,13 @@ func init() {
 				Scope:          &base.ScopeConfig{Type: base.ScopeProject},
 				SupportsUpdate: true,
 				UpdateMethod:   base.UpdateMethodPut,
+				// Schema requires containerName + region; OVH's GET response
+				// uses `name` and lacks `region`/`containerName`. Inject the
+				// URL-derived values so discovery sync passes validation.
+				URLFieldInjection: map[string]string{
+					"containerName": "ResourceName",
+					"region":        "Region",
+				},
 			},
 			RequestTransformer: containerRegionTransformer,
 			Operations: []resource.Operation{


### PR DESCRIPTION
## Summary

OVH GET responses omit fields that live only in the URL (`serviceName`,
`kubeId`, `registryId`, `clusterId`, `engine`, `region`, `zone`, parent
IDs). Several PKL schemas mark those required, so formae's
`resource_persister.validateRequiredFields` silently dropped every
discovered resource of those types and the discovery inventory wait
timed out at 50 minutes.

Initial bug surfaced as `OVH::Kube::Cluster` discovery timing out at
50m even though `Create OOB`, `List`, and `Read` all succeeded. Audit
of every required PKL field vs. each provisioner's `Read` response
showed the same pattern across kube/registry/database/storage/dns/
compute resources.

## Fix

Two-pronged, matching the codebase's split between hand-rolled and
base-framework provisioners.

**Hand-rolled (inject URL fields directly into the response body in
`Read`, and `Status` where it returns `ResourceProperties`):**

- `kube/cluster` — `serviceName`
- `kube/nodepool` — `serviceName`, `kubeId`
- `kube/oidc` — `serviceName`, `kubeId`
- `kube/iprestriction` — `serviceName`, `kubeId` (Create + Read)
- `registry/registry` — `serviceName`
- `registry/user` — `serviceName`, `registryId`
- `registry/oidc` — `serviceName`, `registryId`
- `registry/iprestriction` — `serviceName`, `registryId`, `type`
- `database/service` — `serviceName`, `engine`
- `database/nested` (database, integration, ip_restriction, kafka_acl,
  kafka_topic, postgresql_connection_pool, user) — `serviceName`,
  `engine`, `clusterId`
- `network/private_subnet` — `networkId`

**Base framework — add `ResourceConfig.URLFieldInjection` and apply in
Create/Read/Update/Status after `ResponseTransformer`. Configure the
at-risk resources:**

- `compute/Instance` — `region`
- `compute/Volume` — `region`
- `compute/VolumeSnapshot` — `volume_id` from `ParentResource`
- `storage/Container` — `containerName` from `ResourceName`, `region`
- `dns/Record` — `zone`
- `dns/Redirection` — `zone`

The validation log from the original failing run already showed
`VolumeSnapshot` and `Storage::Container` failing with the same
`missing required fields` error during the kube-cluster discovery
test, confirming this is not specific to kube.

## Verification

- `OVH::Kube::Cluster` discovery test: previously 50m timeout, now
  passes in 4m 43s (verified locally end-to-end with the OVH API).
- `go build ./...` clean across the plugin.
- 51 existing unit tests pass.
- Other discovery tests not run end-to-end here (each requires 5-15 min
  cluster/instance/registry provisioning); the fix mirrors the
  verified cluster pattern exactly.

## Test plan

- [x] CI matrix runs `make conformance-test-discovery` for every
  `testdata/*.pkl` after merge — should turn previously-timing-out
  tests green.
- [x] If any discovery still times out, check the run's resource_persister
  debug log for `Validation of required fields failed` — that's the
  same failure mode and indicates a missed schema field.