### PR TITLE
schema: RFC-0043 typed edge annotations (attachesTo + runtimeDependency)

### DIFF
--- a/schema/pkl/PklProject
+++ b/schema/pkl/PklProject
@@ -2,7 +2,7 @@ amends "pkl:Project"
 
 dependencies {
   ["formae"] {
-    uri = "package://hub.platform.engineering/plugins/pkl/schema/pkl/formae/formae@0.84.0"
+    uri = "package://hub.platform.engineering/plugins/pkl/schema/pkl/formae/formae@0.86.0"
   }
 }
 

--- a/schema/pkl/compute/volumeattachment.pkl
+++ b/schema/pkl/compute/volumeattachment.pkl
@@ -19,12 +19,14 @@ open class VolumeAttachment extends formae.Resource {
   @ovh.FieldHint {
     required = true
     createOnly = true
+    edgeKind = "attachesTo"
   }
   volume_id: String|formae.Resolvable
 
   @ovh.FieldHint {
     required = true
     createOnly = true
+    edgeKind = "attachesTo"
   }
   instance_id: String|formae.Resolvable
 

--- a/schema/pkl/database/service.pkl
+++ b/schema/pkl/database/service.pkl
@@ -47,7 +47,7 @@ open class Node extends formae.SubResource {
   region: String
 
   /// OpenStack private network ID (for private networking)
-  @ovh.FieldHint { createOnly = true }
+  @ovh.FieldHint { createOnly = true; edgeKind = "runtimeDependency" }
   networkId: String?
 
   /// Private subnet ID

--- a/schema/pkl/kube/cluster.pkl
+++ b/schema/pkl/kube/cluster.pkl
@@ -146,7 +146,7 @@ open class Cluster extends formae.Resource {
   kubeProxyMode: KubeProxyMode?
 
   /// Private network ID (OpenStack network UUID)
-  @ovh.FieldHint { createOnly = true; hasProviderDefault = true }
+  @ovh.FieldHint { createOnly = true; hasProviderDefault = true; edgeKind = "runtimeDependency" }
   privateNetworkId: (String|formae.Resolvable)?
 
   /// Private network configuration
@@ -154,11 +154,11 @@ open class Cluster extends formae.Resource {
   privateNetworkConfiguration: PrivateNetworkConfiguration?
 
   /// Subnet ID for load balancers
-  @ovh.FieldHint { createOnly = true; hasProviderDefault = true }
+  @ovh.FieldHint { createOnly = true; hasProviderDefault = true; edgeKind = "runtimeDependency" }
   loadBalancersSubnetId: (String|formae.Resolvable)?
 
   /// Subnet ID for nodes
-  @ovh.FieldHint { createOnly = true; hasProviderDefault = true }
+  @ovh.FieldHint { createOnly = true; hasProviderDefault = true; edgeKind = "runtimeDependency" }
   nodesSubnetId: (String|formae.Resolvable)?
 
   /// API server customization

--- a/schema/pkl/network/floatingip.pkl
+++ b/schema/pkl/network/floatingip.pkl
@@ -40,6 +40,7 @@ open class FloatingIP extends formae.Resource {
   @ovh.FieldHint {
     required = true
     createOnly = true
+    edgeKind = "attachesTo"
   }
   instance_id: String|formae.Resolvable
 
@@ -49,6 +50,7 @@ open class FloatingIP extends formae.Resource {
   @ovh.FieldHint {
     required = true
     createOnly = true
+    edgeKind = "attachesTo"
   }
   ip: String|formae.Resolvable
 

--- a/schema/pkl/network/gateway.pkl
+++ b/schema/pkl/network/gateway.pkl
@@ -60,6 +60,7 @@ open class Gateway extends formae.Resource {
   @ovh.FieldHint {
     required = true
     createOnly = true
+    edgeKind = "attachesTo"
   }
   network_id: String|formae.Resolvable
 
@@ -68,6 +69,7 @@ open class Gateway extends formae.Resource {
   @ovh.FieldHint {
     required = true
     createOnly = true
+    edgeKind = "attachesTo"
   }
   subnet_id: String|formae.Resolvable
 

--- a/testdata/PklProject
+++ b/testdata/PklProject
@@ -6,6 +6,6 @@ dependencies {
 
   // Formae schema - fetched from public registry
   ["formae"] {
-    uri = "package://hub.platform.engineering/plugins/pkl/schema/pkl/formae/formae@0.84.0"
+    uri = "package://hub.platform.engineering/plugins/pkl/schema/pkl/formae/formae@0.86.0"
   }
 }


### PR DESCRIPTION
## Summary

Annotates 8-10 fields with RFC-0043 typed edges:

**`edgeKind = "attachesTo"`** (4 sites): reachability edges where the consumer is "reachable through" the producer at runtime. Destroy order must be producer-first.
- `FloatingIP.instance_id` + `FloatingIP.ip` — FIP reaches the world through its host instance
- `VolumeAttachment.volume_id` + `VolumeAttachment.instance_id` — the attach resource is the literal edge
- `Gateway.network_id` + `Gateway.subnet_id` — gateway sits on the network/subnet pair

**`edgeKind = "runtimeDependency"`** (4 sites): containment edges where the consumer uses the producer + its containment children at runtime.
- `Kube::Cluster.privateNetworkId` — managed cluster needs the PrivateNetwork *and* its PrivateSubnet children for control-plane/node traffic
- `Kube::Cluster.loadBalancersSubnetId` / `nodesSubnetId` — leaf subnet refs
- `Database::Service.nodes[].networkId` — private-networked database needs the network + subnets for endpoints

## Depends on

[formae#484](https://github.com/platform-engineering-labs/formae/pull/484) — engine work that introduces `EdgeKind` and `runtimeDependency` DAG synthesis. Must merge in lockstep.

## Validation

Mechanical schema-only annotations; the engine's `attachesTo` and `runtimeDependency` behavior was validated end-to-end against real AWS in the engine PR's companion debug-conformance run. Local `pkl eval` confirms schemas parse cleanly against `formae@0.86.0`. The `runtimeDependency` cases fire correctly because the producer's child types (`PrivateSubnet`) already declare `parent`.

## Notes

- `formae@0.86.0` pin tracks the snapshot from RFC-0043's engine branch; will track the real release when it ships.
- Out of scope (per scout): `Database::Integration.{destinationServiceId,sourceServiceId}` is borderline-attach but with weaker semantics; left as default. `Instance.networks[].networkId` is polymorphic (public vs private) — would need schema disambiguation before annotation.
- `Port.security_groups` is a plain string list (not Resolvable), so RFC-0043 annotations can't be wired through without a typing change first.

RFC: https://github.com/platform-engineering-labs/rfcs/blob/rfc-0043-typed-dag-edges/rfc-0043-typed-dag-edges.md