### PR TITLE
fix(schema): annotate provider-immutable fields as createOnly + require formae 0.86.0

### DIFF
--- a/formae-plugin.pkl
+++ b/formae-plugin.pkl
@@ -11,7 +11,7 @@ summary = "OVHcloud resource plugin"
 description = "OVH Cloud resource plugin for Formae"
 category = "cloud"
 license = "FSL-1.1-ALv2"
-minFormaeVersion = "0.84.0"
+minFormaeVersion = "0.86.0"
 
 output {
   renderer = new JsonRenderer {}

--- a/schema/pkl/compute/sshkey.pkl
+++ b/schema/pkl/compute/sshkey.pkl
@@ -34,6 +34,7 @@ open class SSHKeyResolvable extends formae.Resolvable {
 open class SSHKey extends formae.Resource {
   @ovh.FieldHint {
     required = true
+    createOnly = true
   }
   name: String
 

--- a/schema/pkl/database/integration.pkl
+++ b/schema/pkl/database/integration.pkl
@@ -55,9 +55,11 @@ open class Integration extends formae.Resource {
   destinationServiceId: (String|formae.Resolvable)
 
   /// Source service ID (if different from clusterId)
+  @ovh.FieldHint { createOnly = true }
   sourceServiceId: (String|formae.Resolvable)?
 
   /// Integration-specific parameters
+  @ovh.FieldHint { createOnly = true }
   parameters: Mapping<String, String>?
 
   // === Computed/Output fields ===

--- a/schema/pkl/database/kafka_acl.pkl
+++ b/schema/pkl/database/kafka_acl.pkl
@@ -48,7 +48,7 @@ open class KafkaAcl extends formae.Resource {
   topic: String
 
   /// Permission level
-  @ovh.FieldHint { required = true }
+  @ovh.FieldHint { required = true; createOnly = true }
   permission: KafkaPermission
 
   // === Computed/Output fields ===

--- a/schema/pkl/database/kafka_topic.pkl
+++ b/schema/pkl/database/kafka_topic.pkl
@@ -42,20 +42,23 @@ open class KafkaTopic extends formae.Resource {
   name: String
 
   /// Number of partitions
-  @ovh.FieldHint { required = true }
+  @ovh.FieldHint { required = true; createOnly = true }
   partitions: Int
 
   /// Replication factor
-  @ovh.FieldHint { required = true }
+  @ovh.FieldHint { required = true; createOnly = true }
   replication: Int
 
   /// Minimum in-sync replicas required for writes
+  @ovh.FieldHint { createOnly = true }
   minInsyncReplicas: Int?
 
   /// Retention period in hours (-1 for unlimited)
+  @ovh.FieldHint { createOnly = true }
   retentionHours: Int?
 
   /// Retention size in bytes (-1 for unlimited)
+  @ovh.FieldHint { createOnly = true }
   retentionBytes: Int?
 
   // === Computed/Output fields ===

--- a/schema/pkl/registry/oidc_registry.pkl
+++ b/schema/pkl/registry/oidc_registry.pkl
@@ -72,6 +72,7 @@ open class Oidc extends formae.Resource {
   oidcAutoOnboard: Boolean?
 
   /// Delete users when removing OIDC config
+  @ovh.FieldHint { createOnly = true }
   deleteUsers: Boolean?
 
   hidden res: OidcResolvable = new {


### PR DESCRIPTION
## Summary
formae 0.86.0 changes the changeset planner so dependents are cascade-**replaced** only when the dependent's referring field is `createOnly`; everything else cascades as an in-place Update. To prevent post-flip Updates from being rejected by the OVH API on fields the schema didn't (yet) mark, this PR:

- Adds `createOnly = true` to 10 leaves across 5 resources, matching `terraform-provider-ovh`'s `ForceNew: true` (SDKv2) and `RequiresReplace()` (plugin-framework) ground truth.
- Bumps `minFormaeVersion` from `0.84.0` to `0.86.0`.

## Annotated fields

| Resource | Fields |
|---|---|
| `OVH::Compute::SshKey` | `name` |
| `OVH::Database::Integration` | `parameters`, `sourceServiceId` |
| `OVH::Database::KafkaACL` | `permission` |
| `OVH::Database::KafkaTopic` | `partitions`, `replication`, `minInsyncReplicas`, `retentionHours`, `retentionBytes` |
| `OVH::Registry::OidcRegistry` | `deleteUsers` |

## Intentional skip
TF marks `ovh_cloud_project_instance.name` as `ForceNew: true`, but OVH's `PUT /cloud/project/{id}/instance/{id}` API actually supports rename (the plugin's `instance_test.go` exercises it). Leaving `OVH::Compute::Instance.name` as mutable.

## Out of scope
- 9 PKL resources have no first-class TF counterpart in `terraform-provider-ovh` (OVH exposes Neutron-style networking via OpenStack APIs): `Network::{FloatingIP, Network, Subnet, Router, Port, SecurityGroup, SecurityGroupRule}`, `Compute::{VolumeAttachment, VolumeSnapshot}`. These need a separate pass against the OpenStack provider; not blocking the 0.86.0 floor bump.
- Over-mark cleanup (a small set of conservatively-marked fields where OVH supports in-place change) is deferred to a follow-up sweep.

## Verification
- `make verify-schema` passes locally after the changes.
- 0 update-fixture clashes.
- TF ground-truth diff: 0 remaining under-marks across the 27 mapped resources.

## Test plan
- [x] `make verify-schema`
- [ ] Conformance nightly on this branch with the new-planner formae build — linked in a comment after open.